### PR TITLE
Use copy-on-write semantics for headers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ppp"
 description = "A Proxy Protocol Parser written in Rust. See HAProxy for the protocol specification."
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Miguel D. Salcedo <miguel@salcedo.cc>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ documentation = "https://docs.rs/ppp"
 lto = true
 debug = true
 
+[features]
+default = []
+
 [dependencies]
 thiserror = "1"
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -6,7 +6,17 @@ const RESPONSE: &str = "HTTP/1.1 200 OK\r\n\r\n";
 
 fn handle_connection(mut client: TcpStream) -> io::Result<()> {
     let mut buffer = [0; 512];
-    let header = parse_header(&mut client, &mut buffer)?;
+    let mut read = 0;
+    let header = loop {
+        read += client.read(&mut buffer[read..])?;
+
+        let header = HeaderResult::parse(&buffer[..read]);
+        if header.is_complete() {
+            break header;
+        }
+
+        println!("Incomplete header. Read {} bytes so far.", read);
+    };
 
     match header {
         HeaderResult::V1(Ok(header)) => println!("V1 Header: {}", header),
@@ -21,19 +31,6 @@ fn handle_connection(mut client: TcpStream) -> io::Result<()> {
 
     client.write_all(RESPONSE.as_bytes())?;
     client.flush()
-}
-
-fn parse_header<'a>(client: &mut TcpStream, buffer: &'a mut [u8]) -> io::Result<HeaderResult<'a>> {
-    loop {
-        let read = client.read(buffer)?;
-        let header = HeaderResult::parse(&buffer[..read]);
-
-        if header.is_complete() {
-            return Ok(header);
-        }
-
-        println!("Incomplete header. Read {} bytes so far.", read);
-    }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ impl<'a> PartialResult for v2::ParseError {
 /// assert_eq!(header, Ok(v1::Header::new(input, v1::Addresses::Unknown)).into());
 /// ```
 #[derive(Debug, PartialEq)]
+#[must_use = "this `HeaderResult` may contain a V1 or V2 `Err` variant, which should be handled"]
 pub enum HeaderResult<'a> {
     V1(Result<v1::Header<'a>, v1::BinaryParseError>),
     V2(Result<v2::Header<'a>, v2::ParseError>),

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -9,6 +9,7 @@ pub use crate::ip::{IPv4, IPv6};
 pub use error::{BinaryParseError, ParseError};
 pub use model::{Addresses, Header, SEPARATOR, TCP4, TCP6, UNKNOWN};
 pub use model::{PROTOCOL_PREFIX, PROTOCOL_SUFFIX};
+use std::borrow::Cow;
 use std::net::{AddrParseError, Ipv4Addr, Ipv6Addr};
 use std::str::{from_utf8, FromStr};
 
@@ -93,7 +94,10 @@ fn parse_header(header: &str) -> Result<Header, ParseError> {
         return Err(ParseError::InvalidSuffix);
     }
 
-    Ok(Header { header, addresses })
+    Ok(Header {
+        header: Cow::Borrowed(header),
+        addresses,
+    })
 }
 
 /// Parses the addresses and ports from a PROXY protocol header for IPv4 and IPv6.

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -179,6 +179,19 @@ impl FromStr for Addresses {
     }
 }
 
+impl FromStr for Header<'static> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let header = Header::try_from(s)?;
+
+        Ok(Header {
+            header: Cow::Owned(header.header.to_string()),
+            addresses: header.addresses,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -200,7 +200,7 @@ mod tests {
         let text = "PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp4(ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -214,7 +214,7 @@ mod tests {
             Addresses::new_tcp4(ip, ip, port, port),
         );
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -285,7 +285,7 @@ mod tests {
         let text = "PROXY TCP6 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\nHi!";
         let expected = Header::new("PROXY TCP6 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n", Addresses::new_tcp6(ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -300,7 +300,7 @@ mod tests {
             Addresses::new_tcp6(short_ip, ip, port, port),
         );
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -344,7 +344,7 @@ mod tests {
         let text = "PROXY TCP6 ffff::ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp6(short_ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -356,7 +356,7 @@ mod tests {
         let text = "PROXY TCP6 ffff:ffff:ffff:ffff::ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp6(short_ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -368,7 +368,7 @@ mod tests {
         let text = "PROXY TCP6 :: ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp6(short_ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -380,7 +380,7 @@ mod tests {
         let text = "PROXY TCP6 ffff:: ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp6(short_ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -405,7 +405,7 @@ mod tests {
         let text = "PROXY UNKNOWN ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::Unknown);
 
-        assert_eq!(Header::try_from(text), Ok(expected));
+        assert_eq!(Header::try_from(text), Ok(expected.clone()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 

--- a/src/v2/builder.rs
+++ b/src/v2/builder.rs
@@ -140,7 +140,7 @@ impl<'a> WriteToHeader for TypeLengthValue<'a> {
 
         writer.write_all([self.kind].as_slice())?;
         writer.write_all((self.value.len() as u16).to_be_bytes().as_slice())?;
-        writer.write_all(self.value)?;
+        writer.write_all(self.value.as_ref())?;
 
         Ok(MINIMUM_TLV_LENGTH + self.value.len())
     }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -14,6 +14,7 @@ pub use model::{
     Unix, Version, PROTOCOL_PREFIX,
 };
 use model::{MINIMUM_LENGTH, MINIMUM_TLV_LENGTH};
+use std::borrow::Cow;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// Masks the right 4-bits so only the left 4-bits are present.
@@ -142,7 +143,7 @@ impl<'a> TryFrom<&'a [u8]> for Header<'a> {
         );
 
         Ok(Header {
-            header,
+            header: Cow::Borrowed(header),
             version,
             command,
             protocol,
@@ -170,7 +171,7 @@ mod tests {
         input.extend([1, 187]);
 
         let expected = Header {
-            header: input.as_slice(),
+            header: Cow::Borrowed(input.as_slice()),
             version: Version::Two,
             command: Command::Proxy,
             protocol: Protocol::Stream,
@@ -204,7 +205,7 @@ mod tests {
         input.extend([1, 187]);
 
         let expected = Header {
-            header: input.as_slice(),
+            header: input.as_slice().into(),
             version: Version::Two,
             command: Command::Proxy,
             protocol: Protocol::Unspecified,
@@ -236,7 +237,7 @@ mod tests {
         input.extend([127, 0, 0, 2]);
 
         let expected = Header {
-            header: input.as_slice(),
+            header: Cow::Borrowed(input.as_slice()),
             version: Version::Two,
             command: Command::Proxy,
             protocol: Protocol::Stream,
@@ -357,7 +358,7 @@ mod tests {
 
         let header = &input[..input.len() - 1];
         let expected = Header {
-            header,
+            header: header.into(),
             version: Version::Two,
             command: Command::Proxy,
             protocol: Protocol::Stream,
@@ -401,7 +402,7 @@ mod tests {
         input.extend([3, 0, 2, 5, 5]);
 
         let expected = Header {
-            header: input.as_slice(),
+            header: input.as_slice().into(),
             version: Version::Two,
             command: Command::Proxy,
             protocol: Protocol::Stream,
@@ -457,7 +458,7 @@ mod tests {
 
         let header = &input[..input.len() - 5];
         let expected = Header {
-            header,
+            header: header.into(),
             version: Version::Two,
             command: Command::Proxy,
             protocol: Protocol::Stream,
@@ -505,7 +506,7 @@ mod tests {
 
         let header = &input[..input.len() - 5];
         let expected = Header {
-            header,
+            header: header.into(),
             version: Version::Two,
             command: Command::Proxy,
             protocol: Protocol::Unspecified,
@@ -555,7 +556,7 @@ mod tests {
         input.extend([3, 0, 2, 5, 5]);
 
         let expected = Header {
-            header: input.as_slice(),
+            header: input.as_slice().into(),
             version: Version::Two,
             command: Command::Proxy,
             protocol: Protocol::Unspecified,
@@ -596,7 +597,8 @@ mod tests {
         input.extend([1, 187]);
         input.extend([1, 0, 1]);
 
-        let mut tlvs = Header::try_from(input.as_slice()).unwrap().tlvs();
+        let header = Header::try_from(input.as_slice()).unwrap();
+        let mut tlvs = header.tlvs();
 
         assert_eq!(tlvs.next().unwrap(), Err(ParseError::InvalidTLV(1, 1)));
         assert_eq!(tlvs.next(), None);
@@ -652,7 +654,7 @@ mod tests {
 
         let header = &input[..input.len() - 2];
         let expected = Header {
-            header,
+            header: header.into(),
             version: Version::Two,
             command: Command::Local,
             protocol: Protocol::Datagram,
@@ -685,7 +687,7 @@ mod tests {
         input.extend([0xbb, 1]);
 
         let expected = Header {
-            header: input.as_slice(),
+            header: input.as_slice().into(),
             version: Version::Two,
             command: Command::Local,
             protocol: Protocol::Datagram,

--- a/src/v2/model.rs
+++ b/src/v2/model.rs
@@ -119,20 +119,11 @@ pub struct Unix {
     pub destination: [u8; 108],
 }
 
-/// An `Iterator` of `TypeLengthValue`s.
-#[derive(Debug, PartialEq)]
+/// An `Iterator` of `TypeLengthValue`s stored in a byte slice.
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct TypeLengthValues<'a> {
-    bytes: Cow<'a, [u8]>,
+    bytes: &'a [u8],
     offset: usize,
-}
-
-impl Clone for TypeLengthValues<'_> {
-    fn clone(&self) -> TypeLengthValues<'static> {
-        TypeLengthValues {
-            bytes: Cow::Owned(self.bytes.to_vec()),
-            offset: self.offset,
-        }
-    }
 }
 
 /// A Type-Length-Value payload.

--- a/src/v2/model.rs
+++ b/src/v2/model.rs
@@ -234,7 +234,10 @@ impl<'a> TypeLengthValues<'a> {
 
 impl<'a> From<&'a [u8]> for TypeLengthValues<'a> {
     fn from(bytes: &'a [u8]) -> Self {
-        TypeLengthValues { bytes: bytes.into(), offset: 0 }
+        TypeLengthValues {
+            bytes: bytes.into(),
+            offset: 0,
+        }
     }
 }
 


### PR DESCRIPTION
This allows us to model borrowed and owned headers with the same model.

closing #13 