### PR TITLE
Derive clone for Cow types and add to_owned method.

### DIFF
--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -183,12 +183,7 @@ impl FromStr for Header<'static> {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let header = Header::try_from(s)?;
-
-        Ok(Header {
-            header: Cow::Owned(header.header.to_string()),
-            addresses: header.addresses,
-        })
+        Ok(Header::try_from(s)?.to_owned())
     }
 }
 
@@ -213,7 +208,7 @@ mod tests {
         let text = "PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp4(ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -227,7 +222,7 @@ mod tests {
             Addresses::new_tcp4(ip, ip, port, port),
         );
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -298,7 +293,7 @@ mod tests {
         let text = "PROXY TCP6 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\nHi!";
         let expected = Header::new("PROXY TCP6 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n", Addresses::new_tcp6(ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -313,7 +308,7 @@ mod tests {
             Addresses::new_tcp6(short_ip, ip, port, port),
         );
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -357,7 +352,7 @@ mod tests {
         let text = "PROXY TCP6 ffff::ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp6(short_ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -369,7 +364,7 @@ mod tests {
         let text = "PROXY TCP6 ffff:ffff:ffff:ffff::ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp6(short_ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -381,7 +376,7 @@ mod tests {
         let text = "PROXY TCP6 :: ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp6(short_ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -393,7 +388,7 @@ mod tests {
         let text = "PROXY TCP6 ffff:: ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::new_tcp6(short_ip, ip, port, port));
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 
@@ -418,7 +413,7 @@ mod tests {
         let text = "PROXY UNKNOWN ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n";
         let expected = Header::new(text, Addresses::Unknown);
 
-        assert_eq!(Header::try_from(text), Ok(expected.clone()));
+        assert_eq!(Header::try_from(text), Ok(expected.to_owned()));
         assert_eq!(Header::try_from(text.as_bytes()), Ok(expected));
     }
 

--- a/src/v1/model.rs
+++ b/src/v1/model.rs
@@ -93,19 +93,10 @@ pub const SEPARATOR: char = ' ';
 ///
 /// assert_eq!(Err(ParseError::InvalidProtocol), "PROXY tcp4\r\n".parse::<Addresses>());
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Header<'a> {
     pub header: Cow<'a, str>,
     pub addresses: Addresses,
-}
-
-impl Clone for Header<'_> {
-    fn clone(&self) -> Header<'static> {
-        Header {
-            header: Cow::Owned(self.header.to_string()),
-            addresses: self.addresses,
-        }
-    }
 }
 
 impl<'a> Header<'a> {
@@ -114,6 +105,14 @@ impl<'a> Header<'a> {
         Header {
             header: Cow::Borrowed(header.into()),
             addresses: addresses.into(),
+        }
+    }
+
+    /// Creates an owned clone of this [`Header`].
+    pub fn to_owned(&self) -> Header<'static> {
+        Header {
+            header: Cow::Owned::<'static>(self.header.to_string()),
+            addresses: self.addresses,
         }
     }
 

--- a/src/v2/model.rs
+++ b/src/v2/model.rs
@@ -42,25 +42,13 @@ const UNIX_ADDRESSES_BYTES: usize = 216;
 /// assert_eq!(actual, expected);
 /// assert_eq!(actual.tlvs().collect::<Vec<Result<TypeLengthValue<'_>, ParseError>>>(), vec![Ok(TypeLengthValue::new(Type::NoOp, &[42]))]);
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Header<'a> {
     pub header: Cow<'a, [u8]>,
     pub version: Version,
     pub command: Command,
     pub protocol: Protocol,
     pub addresses: Addresses,
-}
-
-impl Clone for Header<'_> {
-    fn clone(&self) -> Header<'static> {
-        Header {
-            header: Cow::Owned(self.header.to_vec()),
-            version: self.version,
-            command: self.command,
-            protocol: self.protocol,
-            addresses: self.addresses,
-        }
-    }
 }
 
 /// The supported `Version`s for binary headers.
@@ -127,19 +115,10 @@ pub struct TypeLengthValues<'a> {
 }
 
 /// A Type-Length-Value payload.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypeLengthValue<'a> {
     pub kind: u8,
     pub value: Cow<'a, [u8]>,
-}
-
-impl Clone for TypeLengthValue<'_> {
-    fn clone(&self) -> TypeLengthValue<'static> {
-        TypeLengthValue {
-            kind: self.kind,
-            value: Cow::Owned(self.value.to_vec()),
-        }
-    }
 }
 
 /// Supported types for `TypeLengthValue` payloads.
@@ -173,6 +152,17 @@ impl<'a> fmt::Display for Header<'a> {
 }
 
 impl<'a> Header<'a> {
+    /// Creates an owned clone of this [`Header`].
+    pub fn to_owned(&self) -> Header<'static> {
+        Header {
+            header: Cow::Owned(self.header.to_vec()),
+            version: self.version,
+            command: self.command,
+            protocol: self.protocol,
+            addresses: self.addresses,
+        }
+    }
+    
     /// The length of this `Header`'s payload in bytes.
     pub fn length(&self) -> usize {
         self.header[MINIMUM_LENGTH..].len()
@@ -418,6 +408,14 @@ impl<'a, T: Into<u8>> From<(T, &'a [u8])> for TypeLengthValue<'a> {
 }
 
 impl<'a> TypeLengthValue<'a> {
+    /// Creates an owned clone of this [`TypeLengthValue`].
+    pub fn to_owned(&self) -> TypeLengthValue<'static> {
+        TypeLengthValue {
+            kind: self.kind,
+            value: Cow::Owned(self.value.to_vec()),
+        }
+    }
+
     /// Creates a new instance of a `TypeLengthValue`, where the length is determine by the length of the byte slice.
     /// No check is done to ensure the byte slice's length fits in a `u16`.
     pub fn new<T: Into<u8>>(kind: T, value: &'a [u8]) -> Self {

--- a/src/v2/model.rs
+++ b/src/v2/model.rs
@@ -162,7 +162,7 @@ impl<'a> Header<'a> {
             addresses: self.addresses,
         }
     }
-    
+
     /// The length of this `Header`'s payload in bytes.
     pub fn length(&self) -> usize {
         self.header[MINIMUM_LENGTH..].len()


### PR DESCRIPTION
Clone and ToOwned require the original's lifetime to extend to the clone for copy-on-write types. That is why std::borrow::Cow has its own to_owned method.