### PR TITLE
Fix types for SSL, SSL sub-tlvs, and NetworkNamespace

### DIFF
--- a/src/v2/model.rs
+++ b/src/v2/model.rs
@@ -124,18 +124,18 @@ pub struct TypeLengthValue<'a> {
 /// Supported types for `TypeLengthValue` payloads.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Type {
-    ALPN = 1,
+    ALPN = 0x01,
     Authority,
     CRC32C,
     NoOp,
     UniqueId,
-    SSL = 20,
+    SSL = 0x20,
     SSLVersion,
     SSLCommonName,
     SSLCipher,
     SSLSignatureAlgorithm,
     SSLKeyAlgorithm,
-    NetworkNamespace = 30,
+    NetworkNamespace = 0x30,
 }
 
 impl<'a> fmt::Display for Header<'a> {


### PR DESCRIPTION
See the "spec": https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt - they're hex 20/30, not decimal 20/30.

This bit us in production (whoops!) and I shipped a workaround, only remembering today to contribute the fix upstream.

I've also changed the value of `ALPN` to `0x01` for consistency (since type is a u8, acceptable values are from `0x00` to `0xff`).